### PR TITLE
fix: hltv support

### DIFF
--- a/src/netmsg_doer/client_data.rs
+++ b/src/netmsg_doer/client_data.rs
@@ -8,8 +8,21 @@ impl Doer for SvcClientData {
     }
 
     fn parse(i: &[u8], aux: AuxRefCell) -> Result<Self> {
-        let mut br = BitReader::new(i);
         let aux = aux.borrow();
+
+        if aux.is_hltv {
+            return Ok((
+                i,
+                Self {
+                    has_delta_update_mask: false,
+                    delta_update_mask: None,
+                    client_data: Default::default(),
+                    weapon_data: None,
+                },
+            ));
+        }
+
+        let mut br = BitReader::new(i);
 
         let has_delta_update_mask = br.read_1_bit();
         let delta_update_mask = if has_delta_update_mask {
@@ -58,9 +71,14 @@ impl Doer for SvcClientData {
         let aux = aux.borrow();
 
         let mut writer = ByteWriter::new();
-        let mut bw = BitWriter::new();
 
         writer.append_u8(self.id());
+
+        if aux.is_hltv {
+            return writer.data;
+        }
+
+        let mut bw = BitWriter::new();
 
         bw.append_bit(self.has_delta_update_mask);
 

--- a/src/netmsg_doer/hltv.rs
+++ b/src/netmsg_doer/hltv.rs
@@ -5,11 +5,19 @@ impl Doer for SvcHltv {
         50
     }
 
-    fn parse(i: &[u8], _: AuxRefCell) -> Result<Self> {
+    fn parse(i: &[u8], aux: AuxRefCell) -> Result<Self> {
+        let mut aux = aux.borrow_mut();
+
+        aux.is_hltv = true;
+
         map(le_u8, |mode| SvcHltv { mode })(i)
     }
 
-    fn write(&self, _: AuxRefCell) -> ByteVec {
+    fn write(&self, aux: AuxRefCell) -> ByteVec {
+        let mut aux = aux.borrow_mut();
+
+        aux.is_hltv = true;
+
         let mut writer = ByteWriter::new();
 
         writer.append_u8(self.id());

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,6 +14,12 @@ pub struct Aux {
     pub delta_decoders: DeltaDecoderTable,
     pub max_client: u8,
     pub custom_messages: CustomMessage,
+
+    /// True if the demo was recorded by an HLTV client, false otherwise.
+    ///
+    /// HLTV clients can receive different data from the game server for messages like
+    /// [SvcClientData], which affects parsing.
+    pub is_hltv: bool,
 }
 
 impl Aux {
@@ -22,6 +28,7 @@ impl Aux {
             delta_decoders: get_initial_delta(),
             max_client: 1,
             custom_messages: CustomMessage::new(),
+            is_hltv: false,
         }
     }
 


### PR DESCRIPTION
I ran into this issue trying to parse HLTV client demos and wanted to offer a potential fix.

Quick overview:

- HLTV clients seem to encode SVC_CLIENTDATA messages differently than normal clients. I assume this _could_ apply to other structs too, but I have not identified which, if any.
- In particular, SVC_CLIENTDATA messages in HLTV client demos have none of the actual "client data" attached (delta structs and such)
- HLTV client demos have an SVC_HLTV message in them towards the start of the file. I've found that the first `NetMessage` frame will contain SVC_PRINT then an SVC_HLTV message, followed by the rest of normal startup messages. SVC_DIRECTOR messages can follow throughout the demo based on mod-specific behavior.

I suggest a flag in the demo state (`Aux` data) to indicate whether we're in an HLTV context. Any parsers that need to access it (SVC_CLIENTDATA) or mutate it (SVC_HLTV) can do so, and other parsers are unaffected.

The important changes are:

- `Aux` contains a new `bool` field, `is_hltv`
- SVC_HLTV will set `is_hltv` flag to true in `Aux` state
- SVC_CLIENTDATA will skip reading/writing delta structs based on `is_flag` value in `Aux` state

I also tried converting a normal demo to HLTV by inserting the SVC_HLTV message and did get something playable, so it seems like this is mostly okay for writing too, though I couldn't change spec mode or move in game. There may be other differences in HLTV demos that make it work; replicating `dem_forcehltv 1` is not as simple as adding that one message it seems.

Here's some HLTV demos for testing if you like: [hltv.zip](https://github.com/user-attachments/files/18671634/hltv.zip).

p.s many thanks for extracting this into its own crate! It's been a great library to work with so far.