### PR TITLE
fix: crashed client support

### DIFF
--- a/src/demo_parser.rs
+++ b/src/demo_parser.rs
@@ -15,7 +15,7 @@ use crate::{
         Aux, AuxRefCell, ClientData, ConsoleCommand, Demo, DemoBuffer, DemoInfo, Directory,
         DirectoryEntry, Event, EventArgs, Frame, FrameData, Header, MessageData, MoveVars,
         NetworkMessage, NetworkMessageType, RefParams, SequenceInfo, Sound, UserCmd,
-        WeaponAnimation,
+        WeaponAnimation, FALLBACK_DIRECTORY_ENTRY_TYPE,
     },
 };
 
@@ -161,8 +161,8 @@ pub fn parse_fallback_directory<'a>(
     }
 
     let fallback_entry = DirectoryEntry {
-        type_: -1,
-        description: "Fallback".into(),
+        type_: FALLBACK_DIRECTORY_ENTRY_TYPE,
+        description: vec![],
         flags: -1,
         cd_track: -1,
         track_time: 0.0,

--- a/src/demo_writer.rs
+++ b/src/demo_writer.rs
@@ -39,7 +39,7 @@ impl Demo {
 
         let mut entry_offsets: Vec<(usize, usize)> = vec![];
 
-         for entry in &self.directory.entries {
+        for entry in &self.directory.entries {
             let mut has_written_next_section = false;
 
             let entry_offset_start = writer.get_offset();

--- a/src/demo_writer.rs
+++ b/src/demo_writer.rs
@@ -39,9 +39,7 @@ impl Demo {
 
         let mut entry_offsets: Vec<(usize, usize)> = vec![];
 
-        let mut entries = self.directory.entries.iter().peekable();
-
-        while let Some(entry) = entries.next() {
+         for entry in &self.directory.entries {
             let mut has_written_next_section = false;
 
             let entry_offset_start = writer.get_offset();
@@ -246,7 +244,7 @@ impl Demo {
                 }
             }
 
-            if !has_written_next_section && matches!(entries.peek(), Some(_)) {
+            if !has_written_next_section {
                 writer.append_u8(5u8);
                 writer.append_f32(0.);
                 writer.append_i32(0);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1846,3 +1846,20 @@ pub struct SvcSendCvarValue2 {
     pub request_id: u32,
     pub name: ByteVec,
 }
+
+/// Tells dem how to handle demo files that are missing directory metadata.
+///
+/// While recording a demo, frames are written continuously to the file as they are rendered in
+/// game. When the game client stops recording, the demo file is enriched with further details like
+/// directory entries. If the client crashes before this point, those details are not written, but
+/// much of the frame data is still intact.
+///
+/// A "fallback directory" collects all the parseable frames until the end of the file into a single
+/// synthetic [DirectoryEntry].
+pub enum MissingDirectoryBehavior {
+    /// Synthesize a directory from the available frame data in the file.
+    Autofix,
+
+    /// Treats unfinalized demo files as an error.
+    Error,
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -67,8 +67,6 @@ pub struct Directory {
     pub entries: Vec<DirectoryEntry>,
 }
 
-pub const FALLBACK_DIRECTORY_ENTRY_TYPE: i32 = -1;
-
 #[derive(Debug, Clone)]
 pub struct DirectoryEntry {
     pub type_: i32,

--- a/src/types.rs
+++ b/src/types.rs
@@ -67,6 +67,8 @@ pub struct Directory {
     pub entries: Vec<DirectoryEntry>,
 }
 
+pub const FALLBACK_DIRECTORY_ENTRY_TYPE: i32 = -1;
+
 #[derive(Debug, Clone)]
 pub struct DirectoryEntry {
     pub type_: i32,
@@ -1845,21 +1847,4 @@ pub struct SvcSendCvarValue {
 pub struct SvcSendCvarValue2 {
     pub request_id: u32,
     pub name: ByteVec,
-}
-
-/// Tells dem how to handle demo files that are missing directory metadata.
-///
-/// While recording a demo, frames are written continuously to the file as they are rendered in
-/// game. When the game client stops recording, the demo file is enriched with further details like
-/// directory entries. If the client crashes before this point, those details are not written, but
-/// much of the frame data is still intact.
-///
-/// A "fallback directory" collects all the parseable frames until the end of the file into a single
-/// synthetic [DirectoryEntry].
-pub enum MissingDirectoryBehavior {
-    /// Synthesize a directory from the available frame data in the file.
-    Autofix,
-
-    /// Treats unfinalized demo files as an error.
-    Error,
 }


### PR DESCRIPTION
Hey, another edge case to consider: handling a demo from a game client that crashed during recording.

### Context

From what I can tell, demo recording works roughly like:

1. `record` command starts demo recording
2. Client writes header to file. "Directory offset" is 0.
3. Client continuously writes frames to file
4. `stop` command stops demo recording
5. Client "finalizes" demo: organize frames into directory entries, add directory metadata, update header, etc.

So if the client never gets to that finalization step, the demo will have a slightly different format. Playing the demo will show a warning in console:

> WARNING! Demo had bogus number of directory entries!

### Important changes

- Parsing: `parse_demo` will check the header's directory offset to determine if the demo was finalized
  - Finalized demos continue to `parse_directory` as normal
  - Unfinalized demos continue to `parse_fallback_directory`. This parser reads frames until EOF or error, then creates a `DirectoryEntry` with a fixed `type_` value. All frames that were read get associated with this entry.
- Writing: `Demo::write_to_bytes` will peek at entries to determine if the demo's using a fallback directory. If so, it will invalidate any expectations for multiple directory entries, and skip writing directory metadata to the file.

So far it seems this is enough to allow reading / modifying unfinalized demos. For testing I was able to read a demo, add an SVC_PRINT message, write the demo, and play it. The directory entries warning is still present and playback seems okay.

### Caveats

`parse_fallback_directory` does not consume all data when reading frames; it reads frames until EOF _or error_. So on error, there could be input remaining in the demo.

For example, on the demo I was using, it threw an error towards EOF when it hits an unknown chunk of 142 bytes. I'm not sure if this is partial directory info, malformed / incomplete frame(s), or something else. That chunk is the only diff between files if I open & write w/o modifications:

![image](https://github.com/user-attachments/assets/67d03032-bff2-4cb3-9048-cb93160d0d66)

Missing this chunk doesn't seem to affect playback though. You could consider re-appending whatever's leftover after frames are read somehow, then it'd be a 1:1 match. Alternatively, some corrective procedure could be implemented to finalize the demo like an actual client does. HLAE has/had some stuff like this, maybe coL demo player too, but I haven't checked how they work exactly.